### PR TITLE
Skip provisioning tests outside of master merges

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,7 +1,7 @@
 name: Test Provisioning
 
 # Provisioning tests are expensive, so we should only run them on master merges
-# and version tags (until later determined to be insufficent)
+# (until later determined to be insufficent)
 on:
   push:
     branches:
@@ -9,9 +9,6 @@ on:
     paths-ignore:
     - 'docs/**'
     - '*.md'
-    tags:
-    - 'v*'
-  pull_request: []
 
 jobs:
   macos-provision:


### PR DESCRIPTION
Trying to avoid lots of macOS action spend :/