### PR TITLE
Fix excessive logging verbosity on sub-step runs

### DIFF
--- a/src/mstrap.cr
+++ b/src/mstrap.cr
@@ -32,7 +32,7 @@ require "./mstrap/steps/**"
 
 # Defines top-level constants and shared utilities
 module MStrap
-  Log          = ::Log.for(self)
+  Log          = ::Log.for("mstrap")
   LogFormatter = ::Log::Formatter.new do |entry, io|
     if io.tty?
       io << entry.message

--- a/src/mstrap/cli.cr
+++ b/src/mstrap/cli.cr
@@ -210,8 +210,6 @@ module MStrap
           load_cli_options!(options)
           load_bootstrap_options!(options)
 
-          MStrap.initialize_logger!
-
           config = load_configuration!
 
           logw "Strap in!"
@@ -254,6 +252,8 @@ module MStrap
       self.options.config_path = options.string["config_path"] if options.string.has_key?("config_path")
       self.options.force = options.bool["force"] if options.bool.has_key?("force")
       self.options.skip_project_update = options.bool["skip_project_update"] if options.bool.has_key?("skip_project_update")
+
+      MStrap.initialize_logger!
     end
 
     private def load_bootstrap_options!(options)

--- a/src/mstrap/steps/runtimes_step.cr
+++ b/src/mstrap/steps/runtimes_step.cr
@@ -45,8 +45,7 @@ module MStrap
                            runtime.installed_versions.last
                          end
 
-        logn "--> Setting default #{runtime.language_name} version to #{latest_version}: "
-        log "Setting default #{runtime.language_name} version to #{latest_version}: "
+        log "--> Setting default #{runtime.language_name} version to #{latest_version}: "
         unless cmd "asdf global #{runtime.asdf_plugin_name} #{latest_version}", quiet: true
           logc "Could not set global #{runtime.language_name} version to #{latest_version}"
         end


### PR DESCRIPTION
`MStrap.initialize_logger!` was only getting called for step-less runs (i.e. just running `mstrap`) meaning that calling something like `mstrap projects` would log to STDOUT in the default, verbose Crystal `Log` formatter. This was gross and duplicative, and also prevented logging to `mstrap.log`.