### PR TITLE
Add support for syncing with upstream repos for projects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,7 @@ if embedded_openssl
 endif
 
 crystal_build_flags = [
+  '--error-trace',
   '--cross-compile',
   '--target',
   target_triple,

--- a/src/mstrap/configuration.cr
+++ b/src/mstrap/configuration.cr
@@ -67,7 +67,17 @@ module MStrap
             next
           end
         else
-          fetcher = ProfileFetcher.new(profile_config, force: force)
+          begin
+            fetcher = ProfileFetcher.new(profile_config, force: force)
+          rescue ex : URI::Error
+            logc <<-ERR
+An error occurred while trying to parse the URL for the '#{profile_config.name}' profile:"
+#{ex.message}
+
+The URL provided was '#{profile_config.url}'. Please double-check you have provided a valid
+URL according to the WHATWG URL Standard.
+ERR
+          end
 
           if !MStrap.mstrapped? && fetcher.git_url? && !MStrap::Platform.has_git?
             logw "Skipping profile '#{profile_config.name}' fetch, as git has not yet been installed."

--- a/src/mstrap/defs/project_def.cr
+++ b/src/mstrap/defs/project_def.cr
@@ -19,6 +19,9 @@ module MStrap
       @[HCL::Attribute]
       property repo : String = ""
 
+      @[HCL::Attribute(presence: true)]
+      property repo_upstream : String? = nil
+
       @[HCL::Attribute]
       property? run_scripts = true
 
@@ -37,6 +40,7 @@ module MStrap
       getter? hostname_present = false
       getter? path_present = false
       getter? port_present = false
+      getter? repo_upstream_present = false
       getter? runtimes_present = false
       getter? upstream_present = false
       getter? web_present = false
@@ -47,6 +51,7 @@ module MStrap
         @path,
         @port,
         @repo,
+        @repo_upstream,
         @run_scripts,
         @runtimes,
         @upstream,
@@ -62,6 +67,7 @@ module MStrap
         self.path = other.path if other.path_present?
         self.port = other.port if other.port_present?
         self.repo = other.repo
+        self.repo_upstream = other.repo_upstream if other.repo_upstream_present?
         self.run_scripts = other.run_scripts?
         self.runtimes = other.runtimes if other.runtimes_present?
         self.upstream = other.upstream if other.upstream_present?

--- a/src/mstrap/profile_fetcher.cr
+++ b/src/mstrap/profile_fetcher.cr
@@ -153,15 +153,15 @@ module MStrap
         raise GitProfileFetchError.new(config)
       end
 
-      if config.revision
-        git_checkout_profile_revision!
+      if revision = config.revision
+        git_checkout_profile_revision!(revision)
       end
     end
 
-    private def git_checkout_profile_revision!
+    private def git_checkout_profile_revision!(revision)
       Dir.cd(config.dir) do
-        unless cmd("git", "checkout", config.revision.not_nil!, quiet: true)
-          ProfileFetchError.new("#{config.name}:  could not checkout revision #{config.revision}")
+        unless cmd("git", "checkout", revision, quiet: true)
+          ProfileFetchError.new("#{config.name}:  could not checkout revision #{revision}")
         end
       end
     end
@@ -172,12 +172,12 @@ module MStrap
 
     private def update_profile_from_git!
       Dir.cd(config.dir) do
-        if config.revision
+        if revision = config.revision
           unless cmd("git", "fetch", "origin", quiet: true)
             raise GitProfileFetchError.new(config)
           end
 
-          git_checkout_profile_revision!
+          git_checkout_profile_revision!(revision)
         else
           unless cmd("git", "pull", quiet: true)
             raise GitProfileFetchError.new(config)

--- a/src/mstrap/project.cr
+++ b/src/mstrap/project.cr
@@ -157,7 +157,7 @@ module MStrap
             end
 
           unless success
-            logw "Failed to update '#{remote_branch}' branch from remote '#{remote_name}'. There may be a problem that needs to be resolved manually."
+            logw "Failed to update '#{remote_branch}' branch from '#{remote_name}' remote. There may be a problem that needs to be resolved manually."
           end
 
           success

--- a/src/mstrap/project.cr
+++ b/src/mstrap/project.cr
@@ -20,6 +20,7 @@ module MStrap
     @path : String
     @port : Int32?
     @repo : String
+    @repo_upstream : String?
     @run_scripts : Bool
     @runtimes : Array(String)
     @upstream : String?
@@ -43,6 +44,9 @@ module MStrap
 
     # Returns the configured GitHub path or URI for the project's repo.
     getter :repo
+
+    # Returns the configured GitHub path or URI for the project's upstream repo, if configured.
+    getter :repo_upstream
 
     # Returns the language runtimes of the project, if specified.
     getter :runtimes
@@ -68,6 +72,7 @@ module MStrap
       @path = File.join(MStrap::Paths::SRC_DIR, project_def.path_present? ? project_def.path.not_nil! : cname)
       @port = (port = project_def.port) ? port.to_i32 : nil
       @repo = project_def.repo
+      @repo_upstream = project_def.repo_upstream
       @run_scripts = project_def.run_scripts?
       @runtimes = project_def.runtimes
       @upstream = project_def.upstream
@@ -81,11 +86,24 @@ module MStrap
 
     # Returns a usable Git URI for the project
     def git_uri
-      @git_uri ||= if repo =~ ABSOLUTE_REPO_URL_REGEX || repo =~ SCP_REPO_REGEX
-                     repo
-                   else
-                     "git@github.com:#{repo}.git"
-                   end
+      @git_uri ||=
+        if repo =~ ABSOLUTE_REPO_URL_REGEX || repo =~ SCP_REPO_REGEX
+          repo
+        else
+          "git@github.com:#{repo}.git"
+        end
+    end
+
+    # Returns a usable Git URI for the project's upstream, or nil if not specified
+    def git_upstream_uri
+      @git_upstream_uri ||=
+        if !repo_upstream
+          nil
+        elsif repo_upstream =~ ABSOLUTE_REPO_URL_REGEX || repo_upstream =~ SCP_REPO_REGEX
+          repo_upstream
+        else
+          "git@github.com:#{repo_upstream}.git"
+        end
     end
 
     # Returns the NGINX upstream for the project. Relevant only to web projects.
@@ -109,7 +127,17 @@ module MStrap
 
     # Clones the project from Git
     def clone
-      cmd("git", "clone", git_uri, path, quiet: true)
+      success = cmd("git", "clone", git_uri, path, quiet: true)
+
+      if success && repo_upstream
+        Dir.cd(path) do
+          success =
+            cmd("git", "remote", "add", "upstream", git_upstream_uri.not_nil!, quiet: true) &&
+              cmd("git", "fetch", "upstream", quiet: true)
+        end
+      end
+
+      success
     end
 
     # Updates the project from Git, including auto-stashing any unstaged and
@@ -117,15 +145,19 @@ module MStrap
     def pull
       Dir.cd(path) do
         git_checkpoint do
-          remote_branch = remote_head_branch_name
-          success = if current_branch != remote_branch
-                      cmd("git checkout #{remote_branch}", quiet: true) && cmd("git pull origin #{remote_branch} --rebase", quiet: true) && cmd("git checkout -", quiet: true)
-                    else
-                      cmd "git pull origin #{remote_branch} --rebase", quiet: true
-                    end
+          remote_name = repo_upstream ? "upstream" : "origin"
+          remote_branch = remote_head_branch_name(remote_name)
+          success =
+            if current_branch != remote_branch
+              cmd("git", "checkout", remote_branch, quiet: true) &&
+                cmd("git", "pull", remote_name, remote_branch, "--rebase", quiet: true) &&
+                cmd("git", "checkout", "-", quiet: true)
+            else
+              cmd "git", "pull", remote_name, remote_branch, "--rebase", quiet: true
+            end
 
           unless success
-            logw "Failed to update '#{remote_branch}' branch from remote. There may be a problem that needs to be resolved manually."
+            logw "Failed to update '#{remote_branch}' branch from remote '#{remote_name}'. There may be a problem that needs to be resolved manually."
           end
 
           success
@@ -161,13 +193,14 @@ module MStrap
     # calling into conventional bootstrapping within a project's
     # `script/bootstrap` or `script/setup` from `mstrap project`.
     protected def default_bootstrap
-      runtime_impls = if runtimes.empty?
-                        MStrap::Runtime.all
-                      else
-                        MStrap::Runtime.all.select do |runtime|
-                          runtimes.includes?(runtime.language_name)
-                        end
-                      end
+      runtime_impls =
+        if runtimes.empty?
+          MStrap::Runtime.all
+        else
+          MStrap::Runtime.all.select do |runtime|
+            runtimes.includes?(runtime.language_name)
+          end
+        end
 
       runtime_impls.each do |runtime|
         Dir.cd(path) do
@@ -201,8 +234,8 @@ module MStrap
       end
     end
 
-    private def remote_head_branch_name
-      meta = `git remote show origin`.chomp.match(/HEAD branch: (.+)\n/)
+    private def remote_head_branch_name(remote_name)
+      meta = `git remote show #{remote_name}`.chomp.match(/HEAD branch: (.+)\n/)
       if meta && (branch_name = meta[1]?)
         branch_name
       else


### PR DESCRIPTION
Added the `repo_upstream` option to project config to enable automatic
syncing of main branches on project forks with their upstream equivalent

This makes fork-based development easier as you no longer need to keep
the main branch up-to-date separately from running mstrap. Other branches,
however, are not automatically updated.

Also fixes #37 