### PR TITLE
Rename --debug to --verbose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ If applicable, add logs or screenshots to help explain your problem. **Please re
 Add any other context about the problem here.
 
 **Checklist**
-- [ ] I have tried running with `--debug` and troubleshooting based on that output
+- [ ] I have tried running with `--verbose` and troubleshooting based on that output
 - [ ] I have provided relevant steps to reproduce
 - [ ] I have provided a log file and/or screenshots and have verified there is nothing sensitive
 - [ ] I am not asking for general troubleshooting/assistance with using the software

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -49,7 +49,7 @@ jobs:
       env:
         STRAP_CI: true
       run: |
-        bin/mstrap --debug \
+        bin/mstrap --verbose \
         --config ${{ secrets.TEST_CONFIG_URL }}
 
     - name: Install required dependencies for ruby

--- a/spec/provisioning/docker/test.sh
+++ b/spec/provisioning/docker/test.sh
@@ -8,7 +8,7 @@ export USER="$(whoami)"
 export SHELL=/bin/bash
 export STRAP_CI=true
 
-MSTRAP_FLAGS=${MSTRAP_FLAGS:-"--debug"}
+MSTRAP_FLAGS=${MSTRAP_FLAGS:-"--verbose"}
 WORKSPACE=/workspace
 
 mkdir -p ~/.ssh && chmod 700 ~/.ssh

--- a/src/mstrap.cr
+++ b/src/mstrap.cr
@@ -59,24 +59,22 @@ module MStrap
     end
   end
 
-  @@debug = false
+  @@verbose = false
 
-  # Set debug mode for `mstrap`
-  def self.debug=(value)
-    @@debug = value
+  # Set verbose mode for `mstrap`
+  def self.verbose=(value)
+    @@verbose = value
   end
 
-  # Returns whether or not `mstrap` is in debug mode.
-  #
-  # NOTE: This is not the same as whether it was _compiled_ in debug mode.
-  def self.debug?
-    @@debug
+  # Returns whether or not `mstrap` is in verbose mode.
+  def self.verbose?
+    @@verbose
   end
 
   # Sets up Log instance that can be used to log to the mstrap log file.
-  # When `MStrap.debug?` is set to `true`, this also logs messages to `STDOUT`.
+  # When `MStrap.verbose?` is set to `true`, this also logs messages to `STDOUT`.
   def self.initialize_logger! : Nil
-    if debug?
+    if verbose?
       FileUtils.mkdir_p(Paths::RC_DIR, 0o755)
       log_file = File.new(MStrap::Paths::LOG_FILE, "a+")
       writer = IO::MultiWriter.new(log_file, STDOUT)

--- a/src/mstrap/cli.cr
+++ b/src/mstrap/cli.cr
@@ -53,11 +53,11 @@ DESC
         end
 
         cmd.flags.add do |flag|
-          flag.name = "debug"
-          flag.short = "-d"
-          flag.long = "--debug"
+          flag.name = "verbose"
+          flag.short = "-v"
+          flag.long = "--verbose"
           flag.default = false
-          flag.description = "Run with debug messaging."
+          flag.description = "Run with verbose messaging."
           flag.persistent = true
         end
 
@@ -96,6 +96,15 @@ DESC
           flag.long = "--skip-project-update"
           flag.default = false
           flag.description = "Skip auto-update of projects."
+          flag.persistent = true
+        end
+
+        cmd.flags.add do |flag|
+          flag.name = "version"
+          flag.short = "-V"
+          flag.long = "--version"
+          flag.default = false
+          flag.description = "Prints version number."
           flag.persistent = true
         end
 
@@ -266,7 +275,7 @@ DESC
     end
 
     private def load_cli_options!(options)
-      MStrap.debug = options.bool["debug"] if options.bool.has_key?("debug")
+      MStrap.verbose = options.bool["verbose"] if options.bool.has_key?("verbose")
       self.options.config_path = options.string["config_path"] if options.string.has_key?("config_path")
       self.options.force = options.bool["force"] if options.bool.has_key?("force")
       self.options.skip_project_update = options.bool["skip_project_update"] if options.bool.has_key?("skip_project_update")

--- a/src/mstrap/dsl/logging.cr
+++ b/src/mstrap/dsl/logging.cr
@@ -3,7 +3,7 @@ module MStrap
     module Logging
       # Logs a message, without appending a newline.
       def log(msg)
-        return logn(msg) if MStrap.debug?
+        return logn(msg) if MStrap.verbose?
         print msg
         Log.info { msg }
       end
@@ -34,14 +34,14 @@ module MStrap
       end
 
       # Logs a message at the FATAL level and terminate program. On a TTY, this
-      # will output in red. In debug, this will also print the stacktrace.
+      # will output in red. With --verbose, this will also print the stacktrace.
       def logc(msg)
         Log.fatal { msg }
-        if MStrap.debug?
+        if MStrap.verbose?
           abort msg.colorize(:red)
         else
           puts "!!! #{msg}".colorize(:red)
-          puts "!!! Check #{MStrap::Paths::LOG_FILE} and/or run with --debug for more detail.".colorize(:red)
+          puts "!!! Check #{MStrap::Paths::LOG_FILE} and/or run with --verbose for more detail.".colorize(:red)
           exit 1
         end
       end

--- a/src/mstrap/platform.cr
+++ b/src/mstrap/platform.cr
@@ -74,7 +74,7 @@ module MStrap
         error:  error,
       }
 
-      if MStrap.debug?
+      if MStrap.verbose?
         named = named.merge({
           input:  Process::Redirect::Inherit,
           output: Process::Redirect::Inherit,

--- a/src/mstrap/steps/dependencies_step.cr
+++ b/src/mstrap/steps/dependencies_step.cr
@@ -32,7 +32,7 @@ module MStrap
 
       private def strap_sh
         logn "==> Running strap.sh"
-        unless cmd "bash #{MStrap::Paths::STRAP_SH_PATH} #{MStrap.debug? ? "--debug" : ""}"
+        unless cmd "bash #{MStrap::Paths::STRAP_SH_PATH} #{MStrap.verbose? ? "--debug" : ""}"
           logc "Uhh oh, something went wrong in strap.sh-land."
         end
         success "Finished running strap.sh"
@@ -47,7 +47,7 @@ module MStrap
 
           if File.exists?(brewfile_path)
             log "--> Installing dependencies from Brewfile from profile '#{profile_config.name})': "
-            unless cmd "brew bundle --file=#{brewfile_path} #{MStrap.debug? ? "--verbose" : ""}"
+            unless cmd "brew bundle --file=#{brewfile_path} #{MStrap.verbose? ? "--verbose" : ""}"
               logc "Uhh oh, something went wrong in homebrewland."
             end
             success "OK"

--- a/src/mstrap/supports/mise_installer.cr
+++ b/src/mstrap/supports/mise_installer.cr
@@ -38,7 +38,7 @@ module MStrap
         "MISE_INSTALL_PATH" => MISE_INSTALL_PATH,
       }
 
-      if MStrap.debug?
+      if MStrap.verbose?
         mise_env["MISE_DEBUG"] = "1"
       else
         mise_env["MISE_QUIET"] = "1"

--- a/src/mstrap/supports/rustup_installer.cr
+++ b/src/mstrap/supports/rustup_installer.cr
@@ -19,7 +19,7 @@ module MStrap
 
       install_args = [RUSTUP_INIT_SH_PATH, "--no-modify-path"]
 
-      if MStrap.debug?
+      if MStrap.verbose?
         install_args << "--verbose"
       else
         install_args << "--quiet"


### PR DESCRIPTION
`--debug` was originally picked to mirror `strap.sh` and `brew bundle`, but it's a confusing option from a user perspective because "I want to see more so I can troubleshoot" is a different thing than "I, developer of this tool, want to understand more about what's breaking". `--debug` is really more of the former.