### PR TITLE
ci: install Ruby stdlib on archlinux smoke tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.12.2
+crystal 1.13.2

--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   spectator:
     git: https://gitlab.com/arctic-fox/spectator.git
-    version: 0.11.6
+    version: 0.12.1
 
   term-cursor:
     git: https://github.com/crystal-term/cursor.git

--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ development_dependencies:
     version: ~> 1.6.1
   spectator:
     gitlab: arctic-fox/spectator
-    version: ~> 0.11.6
+    version: ~> 0.12.1
 
 libraries:
   libevent: "*"

--- a/spec/provisioning/docker/archlinux-test.Dockerfile
+++ b/spec/provisioning/docker/archlinux-test.Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:base
 
-RUN pacman --noconfirm -Syu && pacman --noconfirm -S ruby openssh zsh expat sudo
+RUN pacman --noconfirm -Syu && pacman --noconfirm -S ruby ruby-stdlib openssh zsh expat sudo
 
 RUN useradd -m -s /bin/bash -G wheel mstrap
 RUN echo 'mstrap ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
This is for some reason optional now, so needs to be installed seperately