### PR TITLE
Update pkg-config to pkgconf in Homebrew

### DIFF
--- a/spec/provisioning/spec/localhost/dependencies_step_spec.rb
+++ b/spec/provisioning/spec/localhost/dependencies_step_spec.rb
@@ -29,7 +29,7 @@ describe "dependencies step" do
       'jq',
       'mkcert',
       'openssl@3',
-      'pkg-config',
+      'pkgconf',
       'zlib',
     ].freeze
 

--- a/src/mstrap/templates/Brewfile.ecr
+++ b/src/mstrap/templates/Brewfile.ecr
@@ -5,7 +5,7 @@ brew 'git'
 brew 'jq'
 brew 'mkcert'
 brew 'openssl'
-brew 'pkg-config'
+brew 'pkgconf'
 brew 'zlib'
 
 # Language runtime managers


### PR DESCRIPTION
Homebrew moved to pkgconf, and now pkg-config is just an alias