### PR TITLE
Allow skipping libevent when compiled with Crystal 1.15.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install crystal and tool dependencies
       run: |
-        sudo apt install -y crystal libevent-dev libpcre2-dev libssl-dev ninja-build
+        sudo apt install -y crystal libpcre2-dev libssl-dev ninja-build
         sudo apt purge meson
         sudo pip3 install meson
 

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Install crystal and tool dependencies
       run: |
-        sudo apt install -y crystal libevent-dev libpcre2-dev libssl-dev \
+        sudo apt install -y crystal libpcre2-dev libssl-dev \
           curl ninja-build \
           ruby ruby-bundler
         sudo apt purge meson

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := bash
 -include Makefile.local
 
 CODESIGN_IDENTITY ?=
-CRFLAGS           ?= -Devloop=libevent
+CRFLAGS           ?=
 CRYSTAL           ?= $(shell which crystal)
 HOST_ARCH         := $(shell uname -m)
 HOST_OS           := $(shell uname -s | tr '[:upper:]' '[:lower:]')

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Please refer to the [documentation site](https://mstrap.dev) for documentation
 ## Development
 
 1. Install dependencies
-  * macOS: `brew install crystal meson libevent pcre2 openssl`
+  * macOS: `brew install crystal meson pcre2 openssl`
+    * Crystal < 1.15: you'll also need `libevent`
   * Debian/Ubuntu:
     1. [Install Crystal](https://crystal-lang.org/install/)
-    2. `sudo apt install meson libevent-dev libpcre2-dev libssl-dev patchelf`
+    2. `sudo apt install meson libpcre2-dev libssl-dev patchelf`
+      * Crystal < 1.15: you'll also need `libevent-dev`
 2. `git clone git@github.com:maxfierke/mstrap.git`
 3. `make`
 4. `bin/mstrap` will be created

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('mstrap',
   'c',
-  meson_version : '>= 0.60.0',
+  meson_version : '>= 0.62.0',
   license : 'MIT',
   version : '0.7.0',
   default_options : [
@@ -47,7 +47,7 @@ elif target_system == 'darwin'
   endif
 endif
 
-crystal = find_program(get_option('crystal'), required : true)
+crystal = find_program(get_option('crystal'), version : '>= 1.8.0', required : true)
 shards = find_program(get_option('shards'), required : true)
 
 # Basics
@@ -79,14 +79,18 @@ if embedded_openssl
   )
 endif
 
-# Libevent (required for Crystal runtime)
+# Libevent (required for Crystal runtime < 1.15.0 or platforms not supported by
+#           lifetime event loop in Crystal 1.15.0+)
+crystal_requires_libevent = crystal.version().version_compare('< 1.15.0') or \
+  (target_system != 'linux' and target_system != 'darwin' and target_system != 'freebsd')
+
 libevent_dep = dependency(
   'libevent',
   version : '>= 2.1.2',
   static : is_static,
   required : false,
 )
-if not libevent_dep.found()
+if not libevent_dep.found() and crystal_requires_libevent
   cmake = import('cmake')
   libevent_options = cmake.subproject_options()
   libevent_options.add_cmake_defines({
@@ -147,7 +151,6 @@ if embedded_openssl
 endif
 
 crystal_build_flags = [
-  '-Devloop=libevent',
   '--error-trace',
   '--cross-compile',
   '--target',

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.6.1
+    version: 1.6.4
 
   commander:
     git: https://github.com/mrrooijen/commander.git
@@ -18,7 +18,7 @@ shards:
 
   ioctl:
     git: https://github.com/crystal-posix/ioctl.cr.git
-    version: 0.1.2
+    version: 1.0.0
 
   pegmatite:
     git: https://github.com/jemc/crystal-pegmatite.git
@@ -30,17 +30,17 @@ shards:
 
   term-cursor:
     git: https://github.com/crystal-term/cursor.git
-    version: 0.1.0+git.commit.8805d5f686d153db92cf2ce3333433f8ed3708d0
+    version: 0.1.0+git.commit.6bbe0a27a423bc4e0239a051afca05fd36b47e0a
 
   term-prompt:
     git: https://github.com/crystal-term/prompt.git
-    version: 0.1.0+git.commit.bf2b17f885a6c660aea0dda62b0b9da4343ab295
+    version: 0.1.0+git.commit.40918abe27dcba10b6f0cfed2e33a01b2a336733
 
   term-reader:
     git: https://github.com/crystal-term/reader.git
-    version: 0.1.0+git.commit.e174733435c96c745bee31ac5c5d4def3ccf4285
+    version: 0.1.0+git.commit.83adad4a77115dc08efad8057cda3e399d0f1a24
 
   term-screen:
     git: https://github.com/crystal-term/screen.git
-    version: 0.1.0+git.commit.b3a57931b529d60f4e626913feef21b30a6e697a
+    version: 0.1.0+git.commit.8fdecd58ace9e981280b79dc6b16179b173e630b
 


### PR DESCRIPTION
Crystal 1.15.0+ includes the lifetime event driver that natively integrates with the OS on supported platforms, making compiling and linking to libevent unnecessary

The version of term-prompt locked depending upon an older version of term-reader that relied undocumented API that was specific to Crystal's libevent implementation so this also upgrades the affected packages to remove the hard dependency on libevent