### PR TITLE
Switch to musl-cross in CI

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -97,11 +97,13 @@ jobs:
 
     - name: Install musl compiler
       run: |
-        curl -O https://more.musl.cc/x86_64-linux-musl/x86_64-linux-musl-cross.tgz
-        tar xzf x86_64-linux-musl-cross.tgz -C /opt
-        echo "/opt/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
+        curl -O https://github.com/cross-tools/musl-cross/releases/download/20250520/x86_64-unknown-linux-musl.tar.xz
+        echo "a896bad67a4dae7cd7baece62d537fda07f8c74e65fee1b450a691b83e151a9c x86_64-unknown-linux-musl.tar.xz" | sha256sum -c -
+        tar xzf x86_64-unknown-linux-musl.tar.xz -C /opt
+        echo "/opt/x86_64-unknown-linux-musl/bin" >> $GITHUB_PATH
+        sed -i 's/x86_64-linux-musl/x86_64-unknown-linux-musl/g' config/linux-x86_64-musl.ini
 
-    - run: x86_64-linux-musl-gcc --version
+    - run: x86_64-unknown-linux-musl-gcc --version
 
     - name: Build mstrap
       run: |


### PR DESCRIPTION
`musl.cc` is no longer available via GitHub Actions, so switching to a GH-hosted alternative to unblock cross-compilation