### PR TITLE
Update for Homebrew 4.6.0

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -75,6 +75,7 @@ jobs:
           - fedora-38-test
           - fedora-39-test
           - ubuntu-2204-test
+          - ubuntu-2404-test
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.7.2] - 2025-08-13
+
+### Added
+
+* ci: Add Ubuntu 24.04 LTS to CI
+
+### Changed
+
+* macOS: replace `launchdns` with `dnsmasq` for `*.localhost` TLD resolution for
+  bootstrapped web projects
+
+  `launchdns` has been removed from Homebrew after the upstream project was
+  archived, so it is no longer installable. `dnsmasq` is a mostly drop-in
+  replacement
+
+### Bugfixes
+
+* Fixed install of Docker Desktop on macOS via Homebrew
+
+### Removed
+
 ## [0.7.1] - 2025-02-06
 
 ### Added

--- a/spec/provisioning/docker/ubuntu-2404-test.Dockerfile
+++ b/spec/provisioning/docker/ubuntu-2404-test.Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+  apt-get -y install \
+    curl expat libexpat1-dev lsb-release ruby ruby-bundler \
+    openssh-client sudo zsh && \
+  apt-get clean all
+
+RUN useradd -m -s /bin/bash -G sudo mstrap
+RUN echo 'mstrap ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER mstrap
+RUN mkdir -p $HOME/.mstrap
+ADD --chown=mstrap --chmod=600 config.hcl $HOME/.mstrap/
+ADD test.sh test.sh
+CMD [ "./test.sh" ]

--- a/spec/provisioning/spec/localhost/dependencies_step_spec.rb
+++ b/spec/provisioning/spec/localhost/dependencies_step_spec.rb
@@ -59,10 +59,4 @@ describe "dependencies step" do
       end
     end
   end
-
-  describe "launchdns", :if => os[:family] == 'darwin' do
-    describe service('homebrew.mxcl.launchdns') do
-      it { is_expected.to be_enabled }
-    end
-  end
 end

--- a/src/mstrap/bootstrappers/web_bootstrapper.cr
+++ b/src/mstrap/bootstrappers/web_bootstrapper.cr
@@ -7,12 +7,15 @@ module MStrap
 
       def initialize(@config : Configuration)
         super
+        @dnsmasq = DNSMasq.new
         @mkcert = Mkcert.new
       end
 
       # Executes the bootstrapper
       def bootstrap(project : Project) : Bool
         logd "'#{project.name}' is a web project. Running web bootstrapper."
+
+        dnsmasq.install! unless dnsmasq.installed?
 
         if mkcert.installed?
           Dir.cd(Paths::PROJECT_CERTS) do
@@ -27,6 +30,7 @@ module MStrap
         true
       end
 
+      private getter :dnsmasq
       private getter :mkcert
     end
   end

--- a/src/mstrap/platform.cr
+++ b/src/mstrap/platform.cr
@@ -117,6 +117,16 @@ module MStrap
       platform.install_packages!([package_name])
     end
 
+    # Uninstall a list of packages using the platform's package manager
+    def self.uninstall_packages!(packages : Array(String))
+      platform.uninstall_packages!(packages)
+    end
+
+    # Uninstall a single package using the platform's package manager
+    def self.uninstall_package!(package_name : String)
+      platform.uninstall_packages!([package_name])
+    end
+
     # Install a single package using the platform's package manager
     def self.package_installed?(package_name : String)
       platform.package_installed?(package_name)

--- a/src/mstrap/platform/darwin/macos.cr
+++ b/src/mstrap/platform/darwin/macos.cr
@@ -33,6 +33,10 @@ module MStrap
         cmd("brew", ["install"] + packages)
       end
 
+      def self.uninstall_packages!(packages : Array(String))
+        cmd("brew", ["uninstall"] + packages)
+      end
+
       def self.package_installed?(package_name : String)
         cmd("brew list | grep -q '^#{package_name}$'", quiet: true)
       end

--- a/src/mstrap/platform/linux/archlinux.cr
+++ b/src/mstrap/platform/linux/archlinux.cr
@@ -7,6 +7,10 @@ module MStrap
         cmd("pacman", ["-Sy", "--noconfirm", "--needed"] + packages, sudo: true)
       end
 
+      def self.uninstall_packages!(packages : Array(String))
+        cmd("pacman", ["-R", "--noconfirm"] + packages, sudo: true)
+      end
+
       def self.package_installed?(package_name : String)
         cmd("pacman", ["-Qi", package_name], quiet: true)
       end

--- a/src/mstrap/platform/linux/debian.cr
+++ b/src/mstrap/platform/linux/debian.cr
@@ -7,6 +7,10 @@ module MStrap
         cmd("apt-get", ["-y", "install"] + packages, sudo: true)
       end
 
+      def self.uninstall_packages!(packages : Array(String))
+        cmd("apt-get", ["-y", "remove"] + packages, sudo: true)
+      end
+
       def self.package_installed?(package_name : String)
         cmd("dpkg-query -W -f='${Status}' #{package_name} | grep -q 'ok installed'", quiet: true)
       end

--- a/src/mstrap/platform/linux/fedora.cr
+++ b/src/mstrap/platform/linux/fedora.cr
@@ -8,6 +8,10 @@ module MStrap
         cmd("dnf", ["-y", "install"] + packages, sudo: true)
       end
 
+      def self.uninstall_packages!(packages : Array(String))
+        cmd("dnf", ["-y", "remove"] + packages, sudo: true)
+      end
+
       def self.package_installed?(package_name : String)
         cmd("dnf", ["info", "--installed", package_name], quiet: true)
       end

--- a/src/mstrap/platform/linux/rhel.cr
+++ b/src/mstrap/platform/linux/rhel.cr
@@ -7,6 +7,10 @@ module MStrap
         cmd("yum", ["-y", "install"] + packages, sudo: true)
       end
 
+      def self.uninstall_packages!(packages : Array(String))
+        cmd("yum", ["-y", "remove"] + packages, sudo: true)
+      end
+
       def self.package_installed?(package_name : String)
         cmd("yum", ["info", "--installed", package_name], quiet: true)
       end

--- a/src/mstrap/supports/dnsmasq.cr
+++ b/src/mstrap/supports/dnsmasq.cr
@@ -1,0 +1,78 @@
+module MStrap
+  class DNSMasq
+    include DSL
+
+    # :nodoc:
+    CONFIG_BLOCK = <<-CFG
+    # BEGIN MSTRAP
+    address=/localhost/127.0.0.1
+    # END MSTRAP
+    CFG
+
+    # :nodoc:
+    CONFIG_PATH = File.join(MStrap::Paths::HOMEBREW_PREFIX, "etc", "dnsmasq.conf")
+
+    # :nodoc:
+    RESOLVER_CONFIG_PATH = "/etc/resolver/localhost"
+
+    # Returns whether dnsmasq is installed
+    def installed?
+      has_command?("dnsmasq") && config_installed? && resolver_installed?
+    end
+
+    # Runs dnsmasq install process and adds resolver for .localhost
+    def install!
+      install_dnsmasq!
+      install_dnsmasq_config!
+      install_resolver!
+    end
+
+    private def config_installed? : Bool
+      File.exists?(CONFIG_PATH) && File.read(CONFIG_PATH).includes?(CONFIG_BLOCK)
+    end
+
+    private def resolver_installed? : Bool
+      File.exists?(RESOLVER_CONFIG_PATH)
+    end
+
+    private def install_dnsmasq! : Nil
+      return if has_command?("dnsmasq")
+      logn "==> Installing dnsmasq:"
+      MStrap::Platform.install_packages!(["dnsmasq"])
+      success "OK"
+    end
+
+    private def install_dnsmasq_config! : Nil
+      return if config_installed?
+
+      unless File.exists?(CONFIG_PATH)
+        logc "dnsmasq config doesn't exist at #{CONFIG_PATH}"
+      end
+
+      logn "==> Updating dnsmasq config to resolve *.localhost: "
+      File.open(CONFIG_PATH, "a") do |config_file|
+        config_file.puts CONFIG_BLOCK
+      end
+      success "OK"
+      logn "==> Reloading dnsmasq with config...: "
+      unless cmd("brew services restart dnsmasq", quiet: true, sudo: true)
+        logc "An error occurred while restarting dnsmasq. Did you have a prior configuration that conflicts?"
+      end
+      success "OK"
+    end
+
+    private def install_resolver! : Nil
+      unless cmd("mkdir", "-p", "/etc/resolver", sudo: true)
+        logc "An error occurred while creating /etc/resolver"
+      end
+
+      unless cmd("touch #{RESOLVER_CONFIG_PATH}", sudo: true)
+        logc "An error occurred while creating #{RESOLVER_CONFIG_PATH}"
+      end
+
+      unless cmd("echo nameserver 127.0.0.1 | sudo tee -a #{RESOLVER_CONFIG_PATH}")
+        logc "An error occurred while writing #{RESOLVER_CONFIG_PATH}"
+      end
+    end
+  end
+end

--- a/src/mstrap/supports/docker.cr
+++ b/src/mstrap/supports/docker.cr
@@ -104,8 +104,8 @@ module MStrap
     # requiring a reboot.
     def install!
       {% if flag?(:darwin) %}
-        unless app_path || cmd "brew cask install docker"
-          logc "Could not install docker via Homebrew cask"
+        unless app_path || cmd "brew install --cask docker-desktop"
+          logc "Could not install docker-desktop via Homebrew cask"
         end
       {% elsif flag?(:linux) %}
         if !cmd("docker version", quiet: true, sudo: requires_sudo?) || !cmd("docker compose version", quiet: true, sudo: requires_sudo?)

--- a/src/mstrap/templates/Brewfile.ecr
+++ b/src/mstrap/templates/Brewfile.ecr
@@ -23,9 +23,4 @@ if /darwin/ =~ RUBY_PLATFORM
   brew 'gnu-sed'
   brew 'gnu-tar'
   brew 'libiconv'
-
-  # Resolve *.localhost
-  brew 'launchdns', restart_service: true
-else
-  # TODO: dnsmasq or something
 end


### PR DESCRIPTION
Removes the last use of the `brew cask` subcommand, which no longer works.

Also replaces `launchdns` with `dnsmasq`, which has been disabled in `homebrew-core` due to the upstream project being archived.